### PR TITLE
Resolve classes using context class loader during session deserialisation

### DIFF
--- a/src/main/java/org/acme/servlet/redisextension/ClassLoaderObjectInputStream.java
+++ b/src/main/java/org/acme/servlet/redisextension/ClassLoaderObjectInputStream.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme.servlet.redisextension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.io.StreamCorruptedException;
+
+/**
+ * A special ObjectInputStream that loads a class based on a specified
+ * <code>ClassLoader</code> rather than the system default.
+ * <p>
+ * This is useful in dynamic container environments.
+ *
+ * @author Paul Hammant
+ * @version $Id: ClassLoaderObjectInputStream.java 437567 2006-08-28 06:39:07Z bayard $
+ * @since Commons IO 1.1
+ */
+public class ClassLoaderObjectInputStream extends ObjectInputStream {
+
+    /** The class loader to use. */
+    private ClassLoader classLoader;
+
+    /**
+     * Constructs a new ClassLoaderObjectInputStream.
+     *
+     * @param classLoader  the ClassLoader from which classes should be loaded
+     * @param inputStream  the InputStream to work on
+     * @throws IOException in case of an I/O error
+     * @throws StreamCorruptedException if the stream is corrupted
+     */
+    public ClassLoaderObjectInputStream(
+            ClassLoader classLoader, InputStream inputStream)
+            throws IOException, StreamCorruptedException {
+        super(inputStream);
+        this.classLoader = classLoader;
+    }
+
+    /**
+     * Resolve a class specified by the descriptor using the
+     * specified ClassLoader or the super ClassLoader.
+     *
+     * @param objectStreamClass  descriptor of the class
+     * @return the Class object described by the ObjectStreamClass
+     * @throws IOException in case of an I/O error
+     * @throws ClassNotFoundException if the Class cannot be found
+     */
+    protected Class resolveClass(ObjectStreamClass objectStreamClass)
+            throws IOException, ClassNotFoundException {
+        
+        Class clazz = Class.forName(objectStreamClass.getName(), false, classLoader);
+
+        if (clazz != null) {
+            // the classloader knows of the class
+            return clazz;
+        } else {
+            // classloader knows not of class, let the super classloader do it
+            return super.resolveClass(objectStreamClass);
+        }
+    }
+}

--- a/src/main/java/org/acme/servlet/redisextension/RedisSessionManager.java
+++ b/src/main/java/org/acme/servlet/redisextension/RedisSessionManager.java
@@ -267,9 +267,10 @@ public class RedisSessionManager implements SessionManager {
             if (data == null) {
                 return null;
             }
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
             final byte[] attributeBytes = getDecoder().decode(data);
             try (final BufferedInputStream bufferedInputStream = new BufferedInputStream(new ByteArrayInputStream(attributeBytes));
-                    final ObjectInputStream objectInputStream = new ObjectInputStream(bufferedInputStream)) {
+                    final ObjectInputStream objectInputStream = new ClassLoaderObjectInputStream(contextClassLoader, bufferedInputStream)) {
 
                 return objectInputStream.readObject();
             } catch (final ClassNotFoundException | IOException e) {


### PR DESCRIPTION
This PR should resolve at least part of serialisation problems that you have reported on my [Vaadin meets Vert.x](https://vaadin.com/blog/vaadin-meets-vert.x) blog post.

I apologize for late response, but I missed your comment.

The reported problem is due to a ClassLoader issue; please check my reply to your comment on Vaadin blog for explanation.
The trick here is to use an ObjectInputStream that resolves classes using the given classloader (ClassLoaderObjectInputStream class is taken from apache commons-io).

Hope this helps
